### PR TITLE
Dockerize react-app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY . .
+RUN npm ci
+RUN npm run build
+ENV NODE_ENV production
+EXPOSE 3000
+CMD [ "npx", "serve", "build" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+NAME=bicisba
+REPO=react
+all:
+	docker build . --tag $(REPO)
+	docker run --publish 3000:3000 --detach --name $(NAME) $(REPO)
+
+down:
+	docker stop $(NAME)
+	docker rm $(NAME)


### PR DESCRIPTION
Robado de: https://jsramblings.com/dockerizing-a-react-app/

`make` debería levantar la app en `localhost:3000`
